### PR TITLE
[#145] 초대하기 오류 해결

### DIFF
--- a/components/Table/InviteDetailsTable.tsx
+++ b/components/Table/InviteDetailsTable.tsx
@@ -25,6 +25,7 @@ import {
 
 interface TablePaginationProps {
   dashboardId: number;
+  inviteRefresh: boolean;
 }
 
 interface TableProps {
@@ -32,6 +33,8 @@ interface TableProps {
   dashboardId: number;
   refreshPagination: () => void;
 }
+
+const SHOW_ITEMS_SIZE = 5;
 
 /** 초대 내역 컴포넌트에서 하나의 줄을 의미합니다. */
 function Table({ item, dashboardId, refreshPagination }: TableProps) {
@@ -67,15 +70,14 @@ function Table({ item, dashboardId, refreshPagination }: TableProps) {
   );
 }
 
-function InviteDetailsTable({ dashboardId }: TablePaginationProps) {
+function InviteDetailsTable({ dashboardId, inviteRefresh }: TablePaginationProps) {
   const [refreshPaginationToggle, setRefreshPaginationToggle] = useState(false);
   const refreshPagination = () => setRefreshPaginationToggle((prev) => !prev);
-  const SHOW_ITEMS_SIZE = 5;
 
   /**
    * @param handlePagination 페이지네이션 OnClick 동작 함수
    * @param pageNum 현재 페이지 넘버
-   * @param showMembers 화면에 보여줄 Items
+   * @param allItems 모든 Items
    * @param totalPages 총 페이지 수
    * @param totalCount 전체 아이템 수 - API에서 받아올 수 있습니다.
    */
@@ -85,6 +87,7 @@ function InviteDetailsTable({ dashboardId }: TablePaginationProps) {
     type: 'invitationDetails',
     dashboardId,
     refreshPaginationToggle,
+    inviteRefresh,
   });
 
   const tableTitle = '초대 내역';

--- a/hooks/usePagination.ts
+++ b/hooks/usePagination.ts
@@ -11,6 +11,7 @@ interface usePaginationProps {
   dashboardId?: number;
   refreshPaginationToggle?: boolean;
   resetToFirst?: boolean;
+  inviteRefresh?: boolean;
 }
 
 interface usePaginationReturn {
@@ -33,6 +34,7 @@ const usePagination = ({
   dashboardId,
   refreshPaginationToggle,
   resetToFirst,
+  inviteRefresh,
 }: usePaginationProps): usePaginationReturn => {
   const [pageNum, setPageNum] = useState(1);
   const [allItems, setAllItems] = useState<AllItemTypes>([]);
@@ -41,6 +43,7 @@ const usePagination = ({
   const totalPages = Math.ceil(totalCount / showItemNum); // 총 페이지 수
 
   const [checkRefresh, setCheckRefresh] = useState(true);
+  const [checkInviteRefresh, setCheckInviteRefresh] = useState(false);
 
   const handlePagination = async (num: number) => {
     if (loading) return;
@@ -104,11 +107,12 @@ const usePagination = ({
   }, [type, size, showItemNum, dashboardId, allItems]);
 
   useEffect(() => {
-    if (refreshPaginationToggle !== checkRefresh) {
+    if (refreshPaginationToggle !== checkRefresh || inviteRefresh !== checkInviteRefresh) {
       firstFetch();
     }
     setCheckRefresh(refreshPaginationToggle as boolean);
-  }, [refreshPaginationToggle, firstFetch, checkRefresh]);
+    setCheckInviteRefresh(inviteRefresh as boolean);
+  }, [refreshPaginationToggle, firstFetch, checkRefresh, inviteRefresh]);
 
   useEffect(() => {
     firstFetch();

--- a/pages/[dashboardid]/edit.tsx
+++ b/pages/[dashboardid]/edit.tsx
@@ -43,6 +43,8 @@ function BoardEdit({ dashboardId }: BoardEditProps) {
   const [refreshToggle, setRefreshToggle] = useState(false);
   const { members, totalMembers, dashboardData } = useDashboard({ dashboardId, refreshToggle });
   const [reset, setReset] = useState(false);
+  const [inviteRefresh, setInviteRefresh] = useState(false);
+  const refreshInvite = () => setInviteRefresh((prev) => !prev);
   const backHome = () => router.back();
 
   const refresh = () => setRefreshToggle((prev) => !prev);
@@ -67,7 +69,13 @@ function BoardEdit({ dashboardId }: BoardEditProps) {
 
   return (
     <StyledContainer>
-      <DashboardNavbar members={members} totalMembers={totalMembers} dashboard={dashboardData} isMyDashboard={false} />
+      <DashboardNavbar
+        members={members}
+        totalMembers={totalMembers}
+        dashboard={dashboardData}
+        isMyDashboard={false}
+        refreshInvite={refreshInvite}
+      />
       <Sidebar refreshToggle={refreshToggle} reset={reset} setReset={setReset} />
       <StyledWrapper>
         <StyledInWrapper>
@@ -77,7 +85,7 @@ function BoardEdit({ dashboardId }: BoardEditProps) {
             <StyledMainInWrapper>
               <MembersTable dashboardId={Number(dashboardId)} refresh={refresh} />
             </StyledMainInWrapper>
-            <InviteDetailsTable dashboardId={Number(dashboardId)} />
+            <InviteDetailsTable dashboardId={Number(dashboardId)} inviteRefresh={inviteRefresh} />
             <DeleteButton onClick={deleteDashboard} />
           </StyledMainWrapper>
         </StyledInWrapper>


### PR DESCRIPTION
## ✅ 작업 내용

- [x] 수정페이지에서 대시보드 Navbar의 초대하기 이용할 때 페이지 렌더링 안되는 문제 해결
- [x] 초대메세지 보낸 유저에게는 다시 초대메세지 보내지 못하게 구현

## 📍 리뷰 포인트

- 이전에 초대메세지를 보낸 유저에게 다시 보내면 백엔드 쪽에서 막아줬습니다.
- 현재 무슨 이유인지는 모르겠지만 초대메세지 보낸 유저에게 여러 번의 초대메세지를 보낼 수 있는 오류를 경서님이 발견하였습니다.
- 대시보드 초대메세지는 페이지네이션을 이용하여 받는 API라 일단, 100개의 아이템을 받아 입력한 이메일과 비교하는 로직을 작성하였습니다.

## 👀 기타 사항

- API가 바뀌어 해결되면 중복 초대메세지 코드를 없앨 예정입니다.