### PR TITLE
[#176] 대시보드 페이지 스크롤 관련 사이즈 변경

### DIFF
--- a/components/Columns/Column.tsx
+++ b/components/Columns/Column.tsx
@@ -56,7 +56,7 @@ function Column({ title: defaultTitle, columnId, dashboardId, applyColumnDelete 
   };
 
   const firstFetch = async () => {
-    const res = await API.cards.checkCardList({ columnId, size: 10 });
+    const res = await API.cards.checkCardList({ columnId, size: 14 });
     setColumnCardList(res.cards);
     setCardListInfos({ ...cardListInfos, totalCount: res.totalCount, cursorId: Number(res.cursorId) });
   };
@@ -180,13 +180,13 @@ const StyledDiv = styled.div<{ $length: number }>`
 
   ${onTablet} {
     width: 100%;
-    height: ${({ $length }) => ($length < 2 ? '100%' : '19.5vh')};
+    height: ${({ $length }) => ($length < 4 ? '100%' : '21vh')};
     overflow: scroll;
   }
 
   ${onMobile} {
     height: 100%;
-    max-height: 40vh;
+    max-height: 30vh;
   }
 `;
 

--- a/components/Columns/Columns.tsx
+++ b/components/Columns/Columns.tsx
@@ -6,7 +6,6 @@ import { GetColumnListProps } from '@/types/api';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Modal from '../Modal/Modal';
-import { COLORS } from '@/styles/palettes';
 
 interface ColumnProps {
   id: number;


### PR DESCRIPTION
## ✅ 작업 내용

- [x] size 10에서 14로 변경
- [x] 카드 컴포넌트 높이 테블릿, 모바일일때 조금 변경

## 📍 리뷰 포인트

- 대시보드 pc일때 이미지 없는 카드 쭉 만들떄 스크롤 생기는지 확인
- 모바일, pc일때 높이 확인

## 👀 기타 사항

- 마지막날까지 아주 조습니다